### PR TITLE
Fix wrong type interpretation for references in submodel descriptor

### DIFF
--- a/api-wrapper/services/semantics/framework/src/main/java/net/catenax/semantics/framework/aas/model/OneOfReference.java
+++ b/api-wrapper/services/semantics/framework/src/main/java/net/catenax/semantics/framework/aas/model/OneOfReference.java
@@ -14,16 +14,19 @@ package net.catenax.semantics.framework.aas.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 /**
 * OneOfReference
 */
 @JsonTypeInfo(
-  use = JsonTypeInfo.Id.NAME,
-  include = JsonTypeInfo.As.PROPERTY,
+  use = JsonTypeInfo.Id.NONE,
+  defaultImpl = GlobalReference.class,
   property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = GlobalReference.class, name = "GlobalReference")
 })
+@JsonDeserialize(as=GlobalReference.class)
 public interface OneOfReference {
 
 }


### PR DESCRIPTION
semanticId & globalAssedID were missing in the payload from the registry

fixes #46 