### PR TITLE
Fix wrong api-wrapper url in aas-proxy

### DIFF
--- a/api-wrapper/docker-compose.yml
+++ b/api-wrapper/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     ports:
       - "4245:4245" # default
       - "5014:8090" # debugging
+    environment:
+      AASPROXY_WRAPPERURL: http://consumer-api-wrapper:9191/api/service
 
   consumer-api-wrapper:
     build:

--- a/getting-started-guide/docker-compose.yml
+++ b/getting-started-guide/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     ports:
       - "4245:4245" # default
       - "5014:8090"
+    environment:
+      AASPROXY_WRAPPERURL: http://consumer-api-wrapper:9191/api/service
 
   consumer-api-wrapper:
     image: ghcr.io/catenax-ng/catenax-at-home/api-wrapper:0.0.1


### PR DESCRIPTION
Decided not to change this in the dockerfile. This would relates to a new release

Fixes #61 