### PR TITLE
Upgrade dependencies to product-edc 0.1.1 and workaround the catalog limit

### DIFF
--- a/api-wrapper/services/api-wrapper/build.gradle.kts
+++ b/api-wrapper/services/api-wrapper/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 val javaVersion = 11
 val edcGroup = "org.eclipse.dataspaceconnector"
-val edcVersion = "0.0.1-20220818-SNAPSHOT"
+val edcVersion = "0.0.1-20220902-SNAPSHOT"
 
 dependencies {
     implementation("$edcGroup:core-boot:$edcVersion")

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferService.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferService.java
@@ -21,7 +21,7 @@ public class ContractOfferService {
     private final ObjectMapper objectMapper;
     private final OkHttpClient httpClient;
 
-    private static final String CATALOG_PATH = "/catalog?providerUrl=";
+    private static final String CATALOG_PATH = "/catalog?limit=1000000000&providerUrl=";
 
     public ContractOfferService(Monitor monitor, TypeManager typeManager, OkHttpClient httpClient) {
         this.monitor = monitor;


### PR DESCRIPTION
Since no snapshot versions are in artifactory, EDC must be built from source!
The catalog 'limit' is required to get all items because otherwise the catalog size is limited to 50 and api-wrapper can not find the requested items in it.