### PR TITLE
feat: cache catalog

### DIFF
--- a/api-wrapper/services/api-wrapper/build.gradle.kts
+++ b/api-wrapper/services/api-wrapper/build.gradle.kts
@@ -59,6 +59,9 @@ repositories {
     }
     maven {
         url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        mavenContent {
+            snapshotsOnly()
+        }
     }
 }
 

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/ApiWrapperController.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/ApiWrapperController.java
@@ -34,8 +34,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.edr.EndpointDataReference
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -69,8 +67,6 @@ public class ApiWrapperController {
 
     private final ApiWrapperConfig config;
 
-    private Map<String, String> header;
-
     public ApiWrapperController(Monitor monitor,
                                 ContractOfferService contractOfferService,
                                 ContractNegotiationService contractNegotiationService,
@@ -87,10 +83,6 @@ public class ApiWrapperController {
         this.endpointDataReferenceCache = endpointDataReferenceCache;
         this.contractAgreementCache = contractAgreementCache;
         this.config = config;
-
-        if (config.getConsumerEdcApiKeyValue() != null) {
-            this.header = Collections.singletonMap(config.getConsumerEdcApiKeyName(), config.getConsumerEdcApiKeyValue());
-        }
     }
 
     @GET
@@ -121,7 +113,7 @@ public class ApiWrapperController {
                     assetId,
                     config.getConsumerEdcDataManagementUrl(),
                     providerConnectorUrl + IDS_PATH,
-                    header
+                    config.getHeaders()
             );
 
             dataReference = getDataReference(agreementId);
@@ -173,7 +165,7 @@ public class ApiWrapperController {
                     assetId,
                     config.getConsumerEdcDataManagementUrl(),
                     providerConnectorUrl + IDS_PATH,
-                    header
+                    config.getHeaders()
             );
 
             dataReference = getDataReference(agreementId);
@@ -205,9 +197,7 @@ public class ApiWrapperController {
         monitor.info("Initialize contract negotiation");
         var contractOffer = contractOfferService.findContractOffer4AssetId(
                 assetId,
-                config.getConsumerEdcDataManagementUrl(),
-                providerConnectorUrl + IDS_PATH,
-                header
+                providerConnectorUrl + IDS_PATH
         );
 
         if (contractOffer.isEmpty()) {
@@ -236,7 +226,7 @@ public class ApiWrapperController {
         var negotiationId = contractNegotiationService.initiateNegotiation(
                 contractNegotiationRequest,
                 config.getConsumerEdcDataManagementUrl(),
-                header
+                config.getHeaders()
         );
 
         // Check negotiation state
@@ -248,7 +238,7 @@ public class ApiWrapperController {
             negotiation = contractNegotiationService.getNegotiation(
                     negotiationId,
                     config.getConsumerEdcDataManagementUrl(),
-                    header
+                    config.getHeaders()
             );
 
             switch(negotiation.getState()) {

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/ApiWrapperExtension.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/ApiWrapperExtension.java
@@ -50,7 +50,7 @@ public class ApiWrapperExtension implements ServiceExtension {
         var contractAgreementCache = new InMemoryContractAgreementCache(config.getCacheEnabled());
 
         // Setup controller
-        var contractOfferService = new ContractOfferService(monitor, typeManager, httpClient);
+        var contractOfferService = new ContractOfferService(monitor, typeManager, httpClient, config);
         var contractOfferRequestService = new ContractNegotiationService(monitor, typeManager, httpClient);
         var transferProcessService = new TransferProcessService(monitor, typeManager, httpClient);
         var httpProxyService = new HttpProxyService(monitor, httpClient);
@@ -90,6 +90,7 @@ public class ApiWrapperExtension implements ServiceExtension {
 
         builder.cacheEnabled(config.getBoolean(ApiWrapperConfigKeys.CACHE_ENABLED, false));
         builder.callbackTimeout(config.getInteger(ApiWrapperConfigKeys.CALLBACK_TIMEOUT, 20));
+        builder.catalogCachePeriod(config.getLong(ApiWrapperConfigKeys.CATALOG_CACHE_PERIOD, 300L));
 
         return builder.build();
     }

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/config/ApiWrapperConfig.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/config/ApiWrapperConfig.java
@@ -11,6 +11,7 @@ public class ApiWrapperConfig {
     private final Map<String, String> basicAuthUsers;
     private final Boolean cacheEnabled;
     private final int callbackTimeout;
+    private long catalogCachePeriod;
 
     public ApiWrapperConfig(
             String consumerEdcDataManagementUrl,
@@ -18,14 +19,15 @@ public class ApiWrapperConfig {
             String consumerEdcApiKeyValue,
             Map<String, String> basicAuthUsers,
             Boolean cacheEnabled,
-            int callbackTimeout
-    ) {
+            int callbackTimeout,
+            long catalogCachePeriod) {
         this.consumerEdcDataManagementUrl = consumerEdcDataManagementUrl;
         this.consumerEdcApiKeyName = consumerEdcApiKeyName;
         this.consumerEdcApiKeyValue = consumerEdcApiKeyValue;
         this.basicAuthUsers = basicAuthUsers;
         this.cacheEnabled = cacheEnabled;
         this.callbackTimeout = callbackTimeout;
+        this.catalogCachePeriod = catalogCachePeriod;
     }
 
     public String getConsumerEdcDataManagementUrl() {
@@ -52,6 +54,16 @@ public class ApiWrapperConfig {
         return callbackTimeout;
     }
 
+    public Map<String, String> getHeaders() {
+        return getConsumerEdcApiKeyValue() != null
+                ? Collections.singletonMap(getConsumerEdcApiKeyName(), getConsumerEdcApiKeyValue())
+                : Collections.emptyMap();
+    }
+
+    public long getCatalogCachePeriod() {
+        return catalogCachePeriod;
+    }
+
     public static final class Builder {
         private String consumerEdcDataManagementUrl = null;
         private String consumerEdcApiKeyName = "X-Api-Key";
@@ -59,6 +71,7 @@ public class ApiWrapperConfig {
         private Map<String, String> basicAuthUsers = Collections.emptyMap();
         private Boolean cacheEnabled = false;
         private int callbackTimeout = 20;
+        private long catalogCachePeriod;
 
         private Builder() {
         }
@@ -97,6 +110,11 @@ public class ApiWrapperConfig {
             return this;
         }
 
+        public Builder catalogCachePeriod(long catalogCachePeriod) {
+            this.catalogCachePeriod = catalogCachePeriod;
+            return this;
+        }
+
         public ApiWrapperConfig build() {
             return new ApiWrapperConfig(
                     consumerEdcDataManagementUrl,
@@ -104,7 +122,8 @@ public class ApiWrapperConfig {
                     consumerEdcApiKeyValue,
                     basicAuthUsers,
                     cacheEnabled,
-                    callbackTimeout
+                    callbackTimeout,
+                    catalogCachePeriod
             );
         }
     }

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/config/ApiWrapperConfigKeys.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/config/ApiWrapperConfigKeys.java
@@ -22,5 +22,8 @@ public final class ApiWrapperConfigKeys {
     @EdcSetting
     public static final String CALLBACK_TIMEOUT = "wrapper.callback.timeout";
 
+    @EdcSetting(value = "Catalog cache period in seconds. Default is 300 (5 minutes)")
+    public static final String CATALOG_CACHE_PERIOD = "wrapper.cache.catalog.period";
+
     private ApiWrapperConfigKeys() {}
 }

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferService.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferService.java
@@ -1,64 +1,79 @@
 package net.catenax.edc.apiwrapper.connector.sdk.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
+import net.catenax.edc.apiwrapper.config.ApiWrapperConfig;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.groupingBy;
 
 public class ContractOfferService {
     private final Monitor monitor;
     private final ObjectMapper objectMapper;
     private final OkHttpClient httpClient;
+    private final ApiWrapperConfig config;
+    private final Map<String, Map<String, List<ContractOffer>>> byAssetIdCache = new ConcurrentHashMap<>();
 
     private static final String CATALOG_PATH = "/catalog?limit=1000000000&providerUrl=";
 
-    public ContractOfferService(Monitor monitor, TypeManager typeManager, OkHttpClient httpClient) {
+    public ContractOfferService(Monitor monitor, TypeManager typeManager, OkHttpClient httpClient, ApiWrapperConfig config) {
         this.monitor = monitor;
         this.objectMapper = typeManager.getMapper();
         this.httpClient = httpClient;
+        this.config = config;
+        Executors.newScheduledThreadPool(1)
+                .scheduleAtFixedRate(refreshCache(), 0L, config.getCatalogCachePeriod(), SECONDS);
     }
 
     public Optional<ContractOffer> findContractOffer4AssetId(
             String assetId,
-            String consumerEdcDataManagementUrl,
-            String providerConnectorControlPlaneIDSUrl,
-            Map<String, String> header
-    ) throws IOException {
-        var catalog = getCatalogFromProvider(
-                consumerEdcDataManagementUrl,
-                providerConnectorControlPlaneIDSUrl,
-                header
-        );
-        if (catalog.getContractOffers().isEmpty()) {
-            throw new BadRequestException("Provider has not contract offers for us. Catalog is empty.");
+            String providerConnectorControlPlaneIDSUrl
+    ) {
+        if (!byAssetIdCache.containsKey(providerConnectorControlPlaneIDSUrl)) {
+           fetchCatalog(providerConnectorControlPlaneIDSUrl);
         }
 
-        return catalog.getContractOffers()
-                .stream()
-                .filter(it -> it.getAsset().getId().equals(assetId))
-                .findFirst();
+        return Optional.of(providerConnectorControlPlaneIDSUrl)
+                .map(byAssetIdCache::get)
+                .map(it -> it.get(assetId))
+                .flatMap(it -> it.stream().findFirst());
     }
 
-    private Catalog getCatalogFromProvider(
-            String consumerEdcDataManagementUrl,
-            String providerConnectorControlPlaneIDSUrl,
-            Map<String, String> headers
-    ) throws IOException {
-        var url = consumerEdcDataManagementUrl + CATALOG_PATH + providerConnectorControlPlaneIDSUrl;
+    @NotNull
+    private Runnable refreshCache() {
+        return () -> byAssetIdCache.keySet().forEach(this::fetchCatalog);
+    }
+
+    private void fetchCatalog(String providerUrl) {
+        try {
+            var catalog = getCatalogFromProvider(providerUrl);
+            var byId = catalog.getContractOffers().stream().collect(groupingBy(it -> it.getAsset().getId()));
+            byAssetIdCache.put(providerUrl, byId);
+        } catch (IOException e) {
+            monitor.severe("Cannot fetch catalog from " + providerUrl, e);
+        }
+    }
+
+    private Catalog getCatalogFromProvider(String providerConnectorControlPlaneIDSUrl) throws IOException {
+        var url = config.getConsumerEdcDataManagementUrl() + CATALOG_PATH + providerConnectorControlPlaneIDSUrl;
         var request = new Request.Builder()
                 .url(url);
-        headers.forEach(request::addHeader);
+        config.getHeaders().forEach(request::addHeader);
 
         try (var response = httpClient.newCall(request.build()).execute()) {
             var body = response.body();
@@ -73,4 +88,5 @@ public class ContractOfferService {
             throw e;
         }
     }
+
 }

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferService.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferService.java
@@ -27,6 +27,7 @@ public class ContractOfferService {
     private final ObjectMapper objectMapper;
     private final OkHttpClient httpClient;
     private final ApiWrapperConfig config;
+    // ProviderIDSUrl -> AssetId -> List<ContractOffer>
     private final Map<String, Map<String, List<ContractOffer>>> byAssetIdCache = new ConcurrentHashMap<>();
 
     private static final String CATALOG_PATH = "/catalog?limit=1000000000&providerUrl=";

--- a/api-wrapper/services/api-wrapper/src/test/java/net/catenax/edc/apiwrapper/ApiWrapperControllerTest.java
+++ b/api-wrapper/services/api-wrapper/src/test/java/net/catenax/edc/apiwrapper/ApiWrapperControllerTest.java
@@ -25,10 +25,12 @@ import org.mockito.MockedStatic;
 import java.io.IOException;
 import java.net.URI;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -126,7 +128,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> apiWrapperController.getWrapper(providerConnectorUrl, assetId, subUrl, uriInfo)).isInstanceOf(BadRequestException.class);
     }
@@ -139,7 +141,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> apiWrapperController.postWrapper(providerConnectorUrl, assetId, subUrl, "body", uriInfo)).isInstanceOf(BadRequestException.class);
     }
@@ -163,7 +165,7 @@ class ApiWrapperControllerTest {
                 .build();
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyContractNegotiationDto());
         when(httpProxyService.sendGETRequest(any(), any(), any())).thenReturn("theDataResult");
         when(endpointDataReferenceCache.get(any())).thenReturn(endpointDataReferenceTest);
@@ -195,7 +197,7 @@ class ApiWrapperControllerTest {
                 .build();
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyContractNegotiationDto());
         when(httpProxyService.sendPOSTRequest(any(), any(), any(), any(), any())).thenReturn("theDataResult");
         when(endpointDataReferenceCache.get(any())).thenReturn(endpointDataReferenceTest);
@@ -216,7 +218,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyContractNegotiationDto());
 
         assertThatThrownBy(() -> apiWrapperController.getWrapper(providerConnectorUrl, assetId, subUrl, uriInfo)).isInstanceOf(InternalServerErrorException.class);
@@ -230,7 +232,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyContractNegotiationDto());
 
         assertThatThrownBy(() -> apiWrapperController.postWrapper(providerConnectorUrl, assetId, subUrl, "body", uriInfo)).isInstanceOf(InternalServerErrorException.class);
@@ -244,7 +246,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.initiateNegotiation(
                 any(),
                 any(),
@@ -268,7 +270,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyDeclinedContractNegotiationDto());
 
         assertThatThrownBy(() -> apiWrapperController.postWrapper(
@@ -288,7 +290,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.initiateNegotiation(
                 any(),
                 any(),
@@ -312,7 +314,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyErrorContractNegotiationDto());
 
         assertThatThrownBy(() -> apiWrapperController.postWrapper(
@@ -332,7 +334,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyRequestedContractNegotiationDto());
 
         assertThatThrownBy(() -> apiWrapperController.getWrapper(
@@ -351,7 +353,7 @@ class ApiWrapperControllerTest {
         UriInfo uriInfo = mock(UriInfo.class);
 
         when(contractAgreementCache.get(any())).thenReturn(null);
-        when(contractOfferService.findContractOffer4AssetId(any(), any(), any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
+        when(contractOfferService.findContractOffer4AssetId(any(), any())).thenReturn(Optional.of(getDummyContractOffer()));
         when(contractNegotiationService.getNegotiation(any(), any(), any())).thenReturn(getDummyRequestedContractNegotiationDto());
 
         assertThatThrownBy(() -> apiWrapperController.postWrapper(

--- a/api-wrapper/services/api-wrapper/src/test/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferServiceTest.java
+++ b/api-wrapper/services/api-wrapper/src/test/java/net/catenax/edc/apiwrapper/connector/sdk/service/ContractOfferServiceTest.java
@@ -1,0 +1,89 @@
+package net.catenax.edc.apiwrapper.connector.sdk.service;
+
+import net.catenax.edc.apiwrapper.config.ApiWrapperConfig;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContractOfferServiceTest {
+
+    private final TypeManager typeManager = new TypeManager();
+    private final OkHttpClient httpClient = mock(OkHttpClient.class);
+    private final Call call = mock(Call.class);
+    private final ApiWrapperConfig config = mock(ApiWrapperConfig.class);
+
+    private ContractOfferService service;
+
+    @BeforeEach
+    void setUp() {
+        when(httpClient.newCall(any())).thenReturn(call);
+        when(config.getConsumerEdcDataManagementUrl()).thenReturn("http://an-url");
+        when(config.getCatalogCachePeriod()).thenReturn(300L);
+        service = new ContractOfferService(mock(Monitor.class), typeManager, httpClient, config);
+    }
+
+    @Test
+    void shouldCacheCatalog() throws IOException {
+        var contractOffer = createContractOffer("offerId", "assetId");
+        var catalog = createCatalog(contractOffer);
+        when(call.execute()).thenReturn(successfulResponse(catalog));
+        var providerUrl = "http//provider/url";
+
+        var firstOffer = service.findContractOffer4AssetId("assetId", providerUrl);
+        var secondOffer = service.findContractOffer4AssetId("assetId", providerUrl);
+
+        assertThat(firstOffer).containsSame(secondOffer.get());
+        verify(call, times(1)).execute();
+    }
+
+    private Catalog createCatalog(ContractOffer contractOffer) {
+        return Catalog.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .contractOffers(List.of(contractOffer))
+                .build();
+    }
+
+    @NotNull
+    private static ContractOffer createContractOffer(String id, String assetId) {
+        return ContractOffer.Builder.newInstance()
+                .id(id)
+                .asset(Asset.Builder.newInstance().id(assetId).build())
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+
+    @NotNull
+    private Response successfulResponse(Catalog catalog) {
+        return new Response.Builder()
+                .code(200)
+                .message("any")
+                .body(ResponseBody.create(typeManager.writeValueAsBytes(catalog), okhttp3.MediaType.get("application/json")))
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("http://any").build())
+                .build();
+    }
+}


### PR DESCRIPTION
### what
Caches catalog by provider, and sets a job that refresh it every 5m by default. The period is configurable with the setting 
`wrapper.cache.catalog.period`

### why
To avoid pressure on the catalog endpoint, that's really heavy since the catalog is built from scratch on every request by the client.

### notes
- brought the config object to the `ContractOfferService`, this allowed to remove two parameters from the public method (the consumer url and the headers) as they are always the same during the application lifecycles.
- adding a setting that permits to fetch snapshots from the sonatype repository (without that I wasn't able to build the application)
- 