### PR TITLE
fix: Prevent double slash in connector path called by api-wrapper

### DIFF
--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/HttpProxyService.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/connector/sdk/service/HttpProxyService.java
@@ -52,11 +52,11 @@ public class HttpProxyService {
         return sendRequest(request);
     }
 
-    private HttpUrl getUrl(String connectorUrl, String subUrl, MultivaluedMap<String, String> parameters) {
+    protected HttpUrl getUrl(String connectorUrl, String subUrl, MultivaluedMap<String, String> parameters) {
         var url = connectorUrl;
 
         if (subUrl != null && !subUrl.isEmpty()) {
-            url = url + "/" + subUrl;
+            url = url.endsWith("/") ? url + subUrl : url + "/" + subUrl;
         }
 
         HttpUrl.Builder httpBuilder = Objects.requireNonNull(HttpUrl.parse(url)).newBuilder();

--- a/api-wrapper/services/api-wrapper/src/test/java/net/catenax/edc/apiwrapper/connector/sdk/service/HttpProxyServiceTest.java
+++ b/api-wrapper/services/api-wrapper/src/test/java/net/catenax/edc/apiwrapper/connector/sdk/service/HttpProxyServiceTest.java
@@ -1,0 +1,34 @@
+package net.catenax.edc.apiwrapper.connector.sdk.service;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpProxyServiceTest {
+
+    private final Monitor monitorMock = mock(Monitor.class);
+    private final OkHttpClient httpClientMock = mock(OkHttpClient.class);
+
+    @Test
+    void getUrlTest() {
+        HttpProxyService httpProxyService = new HttpProxyService(monitorMock, httpClientMock);
+        MultivaluedMap<String, String> parameters = new MultivaluedHashMap<>();
+
+        String connectorUrl = "https://myconnector:8182/public";
+        String subpath = "subpath";
+
+        HttpUrl url = httpProxyService.getUrl(connectorUrl, subpath, parameters);
+        assertThat(url.url().toString()).isEqualTo(connectorUrl + "/" + subpath);
+
+        url = httpProxyService.getUrl(connectorUrl + "/", subpath, parameters);
+        assertThat(url.url().toString()).isEqualTo(connectorUrl + "/" + subpath);
+    }
+
+}


### PR DESCRIPTION
As part of the dataplane selector we provide a [publicApiUrl in the control planes configuration](https://github.com/catenax-ng/product-edc/tree/develop/edc-extensions/dataplane-selector-configuration) which will be used by the api wrapper to perform a call to the data plane after receiving the endpoint data reference. We have seen the api wrapper putting there double slashes in case the url ends with a slash.

As a workaround we configured the url without a trailing slash. This brings up another known issue, which is about a 302 redirect by jetty in case the trailing slash is not provided. This happened for the data plane to data plane call.

In case an edc should act as consumer and provider at the same time, api wrapper has to fix the double slash issue, to allow both calls.