### PR TITLE
fix: References to 0.1.2 version of product-edc

### DIFF
--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/ApiWrapperExtension.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/ApiWrapperExtension.java
@@ -12,7 +12,7 @@ import net.catenax.edc.apiwrapper.security.BasicAuthenticationService;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.api.auth.AuthenticationRequestFilter;
 import org.eclipse.dataspaceconnector.spi.WebService;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;

--- a/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/config/ApiWrapperConfigKeys.java
+++ b/api-wrapper/services/api-wrapper/src/main/java/net/catenax/edc/apiwrapper/config/ApiWrapperConfigKeys.java
@@ -1,6 +1,6 @@
 package net.catenax.edc.apiwrapper.config;
 
-import org.eclipse.dataspaceconnector.spi.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 
 public final class ApiWrapperConfigKeys {
 


### PR DESCRIPTION
I can't build the 0.1.2 tagged version with the edc version contained in product-edc tagged with 0.1.2.

edc version: 0.0.1-20220922-SNAPSHOT

This should fix it. curious how the image has been released. am I missing something?